### PR TITLE
Fix regex for removing quotes

### DIFF
--- a/lib/mix/tasks/ex_machina.gen.ex
+++ b/lib/mix/tasks/ex_machina.gen.ex
@@ -35,8 +35,8 @@ defmodule Mix.Tasks.ExMachina.Gen do
       |> put_assoc_build(schema_module, associations)
       |> inspect(pretty: true, width: :infinity)
       |> String.replace_leading("%{", "%#{schema_string}{")
-      |> String.replace(~r/"build\((.+)\)"/, "build(\\1)")
-      |> String.replace(~r/"\[build\((.+)\)\]"/, "[build(\\1)]")
+      |> String.replace(~r/"build\(([^\)]+)\)"/, "build(\\1)")
+      |> String.replace(~r/"\[build\(([^\)]+)\)\]"/, "[build(\\1)]")
 
     singular = apply(schema_module, :__schema__, [:source]) |> Inflex.singularize()
     module = "#{schema_string}Factory"

--- a/test/ex_machina_gen_test.exs
+++ b/test/ex_machina_gen_test.exs
@@ -13,6 +13,14 @@ defmodule ExMachinaGenTest do
     :ok
   end
 
+  defmodule Blog.User do
+    use Ecto.Schema
+
+    schema "users" do
+      field(:name, :string)
+    end
+  end
+
   defmodule Blog.Post do
     use Ecto.Schema
 
@@ -23,6 +31,7 @@ defmodule ExMachinaGenTest do
       field(:tags, {:array, :string})
       field(:meta, :map)
       field(:order, :integer)
+      belongs_to(:user, Blog.User)
       timestamps()
     end
   end
@@ -72,6 +81,7 @@ defmodule ExMachinaGenTest do
       assert file =~ ~s(order: 1)
       assert file =~ ~s(inserted_at: ~N[2019-01-01 00:00:00])
       assert file =~ ~s(updated_at: ~N[2019-01-01 00:00:00])
+      assert file =~ ~s/user: build(:user)/
     end
   end
 end


### PR DESCRIPTION
There was a bug in your regex that would cause some extra `"` to be left.

```elixir
defmodule Blog.Post do
  use Ecto.Schema

  schema "posts" do
    field :date, :date
    belongs_to :user, Blog.User
    field :active, :boolean
    belongs_to :group, Blog.Group
  end
```
would generate:

```elixir
def post_factory do
  %Blog.Post{date: ~D[2019-01-01], user: build(:user)", active: true, group: "build(:group)}
end
```

The `.+` was too inclusive, the change makes sure it stops at the first `)` it encounters.